### PR TITLE
Link Kubeflow pipeline article to PDF

### DIFF
--- a/index.html
+++ b/index.html
@@ -573,7 +573,7 @@
                                     <h3 class="article-title">MLOps Pipeline with Kubeflow and MLflow</h3>
                                     <div class="article-meta">July 10, 2025 • 15 min read</div>
                                     <p class="article-excerpt">Building production-ready ML pipelines using Kubeflow for orchestration and MLflow for experiment tracking. Complete guide with code examples.</p>
-                                    <a href="#" class="read-more">Read full article</a>
+                                    <a href="pdfs/kubmlops.pdf" class="read-more" target="_blank">Read full article</a>
                                 </div>
                             </article>
                             


### PR DESCRIPTION
## Summary
- link `kubmlops.pdf` to the **MLOps Pipeline with Kubeflow and MLflow** article so the PDF opens when clicking *Read full article*

## Testing
- `tidy -errors index.html` *(fails: command not found)*
- `apt-get update` *(fails: network access blocked)*

------
https://chatgpt.com/codex/tasks/task_e_6874e14db4d8832d957e0bdc62272a2a